### PR TITLE
Corrected setup.py specification for scikitlearn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "numpy",
         "pandas>=1.0",
         "scipy",
-        "sklearn",
+        "scikit-learn",
         "tensorflow>=2.0",
         "configparser",
         "keras"


### PR DESCRIPTION
When trying to install DeepImpute, an error stems due to the wrong keyword "sklearn" in the setup.py settings. scikit-leanr has now deprecated the use of sklearn which leads to the package not being able to install itself. This is corrected by simply changing to 'scikit-learn'.

Here are the error messages I received which led me to this fix:
```bash
pip install --user .
Processing /home/ubuntu/deepimpute
  Preparing metadata (setup.py) ... done
Collecting configparser
  Downloading configparser-7.2.0-py3-none-any.whl (17 kB)
Collecting keras
  Downloading keras-3.10.0-py3-none-any.whl (1.4 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.4/1.4 MB 24.7 MB/s eta 0:00:00
Requirement already satisfied: numpy in /usr/local/lib/python3.10/dist-packages (from deepimpute==1.2) (2.2.6)
Requirement already satisfied: pandas>=1.0 in /usr/local/lib/python3.10/dist-packages (from deepimpute==1.2) (2.3.0)
Requirement already satisfied: scipy in /usr/local/lib/python3.10/dist-packages (from deepimpute==1.2) (1.15.3)
Collecting sklearn
  Downloading sklearn-0.0.post12.tar.gz (2.6 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [15 lines of output]
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.
      
      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error
      
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```